### PR TITLE
Add unit tests for common request helpers

### DIFF
--- a/internal/common/request_test.go
+++ b/internal/common/request_test.go
@@ -1,0 +1,83 @@
+package common
+
+import (
+	"context"
+	"github.com/gorilla/mux"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestExtractPathParam(t *testing.T) {
+	tests := []struct {
+		name      string
+		vars      map[string]string
+		paramName string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "param present",
+			vars:      map[string]string{"id": "123"},
+			paramName: "id",
+			want:      "123",
+			wantErr:   false,
+		},
+		{
+			name:      "param missing",
+			vars:      map[string]string{},
+			paramName: "id",
+			want:      "",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/", nil)
+			r = mux.SetURLVars(r, tt.vars)
+			got, err := ExtractPathParam(r, tt.paramName)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("wantErr %v got %v", tt.wantErr, err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected %s got %s", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestExtractUserIdFromContext(t *testing.T) {
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "userId present",
+			ctx:     context.WithValue(context.Background(), UserIdKey, "user123"),
+			want:    "user123",
+			wantErr: false,
+		},
+		{
+			name:    "userId missing",
+			ctx:     context.Background(),
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/", nil)
+			r = r.WithContext(tt.ctx)
+			got, err := ExtractUserIdFromContext(r)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("wantErr %v got %v", tt.wantErr, err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected %s got %s", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- create `request_test.go` for package `common`
- add table-driven tests for `ExtractPathParam`
- add table-driven tests for `ExtractUserIdFromContext`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684ecf69e0bc8329a520ccb913cf73d2